### PR TITLE
Add Pipeline::buffer()

### DIFF
--- a/src/Internal/ConcurrentFlatMapIterator.php
+++ b/src/Internal/ConcurrentFlatMapIterator.php
@@ -24,9 +24,14 @@ final class ConcurrentFlatMapIterator implements ConcurrentIterator
      * @param ConcurrentIterator<T> $iterator
      * @param \Closure(T, int):iterable<R> $flatMap
      */
-    public function __construct(ConcurrentIterator $iterator, int $concurrency, bool $ordered, \Closure $flatMap)
-    {
-        $queue = new QueueState;
+    public function __construct(
+        ConcurrentIterator $iterator,
+        int $bufferSize,
+        int $concurrency,
+        bool $ordered,
+        \Closure $flatMap,
+    ) {
+        $queue = new QueueState($bufferSize);
         $this->iterator = new ConcurrentQueueIterator($queue);
         $order = $ordered ? new Sequence : null;
 

--- a/src/Internal/ConcurrentIterableIterator.php
+++ b/src/Internal/ConcurrentIterableIterator.php
@@ -20,7 +20,7 @@ final class ConcurrentIterableIterator implements ConcurrentIterator
     /**
      * @param iterable<T> $iterable
      */
-    public function __construct(iterable $iterable)
+    public function __construct(iterable $iterable, int $bufferSize = 0)
     {
         if (\is_array($iterable)) {
             $this->iterator = new ConcurrentArrayIterator($iterable);
@@ -36,7 +36,7 @@ final class ConcurrentIterableIterator implements ConcurrentIterator
             $iterable = $iterable->getIterator();
         }
 
-        $queue = new QueueState();
+        $queue = new QueueState($bufferSize);
         $this->iterator = new ConcurrentQueueIterator($queue);
 
         async(static function () use ($queue, $iterable): void {

--- a/src/Internal/FlatMapOperation.php
+++ b/src/Internal/FlatMapOperation.php
@@ -23,6 +23,7 @@ final class FlatMapOperation implements IntermediateOperation
      * @param \Closure(T, int):iterable<R> $flatMap
      */
     public function __construct(
+        private readonly int $bufferSize,
         private readonly int $concurrency,
         private readonly bool $ordered,
         private readonly \Closure $flatMap
@@ -45,9 +46,15 @@ final class FlatMapOperation implements IntermediateOperation
                         yield $item;
                     }
                 }
-            })());
+            })(), $this->bufferSize);
         }
 
-        return new ConcurrentFlatMapIterator($source, $this->concurrency, $this->ordered, $this->flatMap);
+        return new ConcurrentFlatMapIterator(
+            $source,
+            $this->bufferSize,
+            $this->concurrency,
+            $this->ordered,
+            $this->flatMap,
+        );
     }
 }


### PR DESCRIPTION
This adds a `buffer()` method to `Pipeline` which allows the user to control the buffer size of any `Queue` objects created within.

This should address the performance issues in https://github.com/amphp/pipeline/issues/20 due to latency between emitting values.