### PR TITLE
Add `Pipeline::apply()`

### DIFF
--- a/src/Emission.php
+++ b/src/Emission.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Amp\Pipeline;
+
+/**
+ * @template-covariant T
+ * @implements \IteratorAggregate<int, T>
+ */
+final class Emission implements \IteratorAggregate
+{
+    /**
+     * @template Tv
+     * @param iterable<Tv> $values
+     * @return self<Tv>
+     */
+    public static function of(iterable $values): self
+    {
+        return new self($values, false);
+    }
+
+    /**
+     * @template Tv
+     * @param iterable<Tv> $values
+     * @return self<Tv>
+     */
+    public static function end(iterable $values = []): self
+    {
+        return new self($values, true);
+    }
+
+    /**
+     * @param iterable<T> $values
+     */
+    private function __construct(
+        private readonly iterable $values,
+        private readonly bool $final,
+    ) {
+    }
+
+    public function isFinal(): bool
+    {
+        return $this->final;
+    }
+
+    /**
+     * @return \Traversable<int, T>
+     */
+    #[\Override]
+    public function getIterator(): \Traversable
+    {
+        // Not using yield from to ensure keys are 0-indexed.
+        foreach ($this->values as $value) {
+            yield $value;
+        }
+    }
+}

--- a/src/Internal/ConcurrentFlatMapIterator.php
+++ b/src/Internal/ConcurrentFlatMapIterator.php
@@ -5,6 +5,7 @@ namespace Amp\Pipeline\Internal;
 use Amp\Cancellation;
 use Amp\Future;
 use Amp\Pipeline\ConcurrentIterator;
+use Amp\Pipeline\Emission;
 use function Amp\async;
 
 /**
@@ -22,7 +23,7 @@ final class ConcurrentFlatMapIterator implements ConcurrentIterator
      * @template R
      *
      * @param ConcurrentIterator<T> $iterator
-     * @param \Closure(T, int):iterable<R> $flatMap
+     * @param \Closure(T, int):Emission<R> $flatMap
      */
     public function __construct(
         ConcurrentIterator $iterator,
@@ -37,8 +38,6 @@ final class ConcurrentFlatMapIterator implements ConcurrentIterator
         $preOrder = $ordered ? new Sequence() : null;
         $postOrder = $ordered ? new Sequence() : null;
 
-        $stop = FlatMapOperation::getStopMarker();
-
         $futures = [];
 
         for ($i = 0; $i < $concurrency; $i++) {
@@ -48,14 +47,13 @@ final class ConcurrentFlatMapIterator implements ConcurrentIterator
                 $flatMap,
                 $preOrder,
                 $postOrder,
-                $stop,
             ): void {
                 foreach ($iterator as $position => $value) {
                     // Force ordering of concurrent coroutines regardless of the emitted order of the source iterator.
                     $preOrder?->barrier($position);
 
                     try {
-                        $iterable = $flatMap($value, $position);
+                        $emission = $flatMap($value, $position);
                     } catch (\Throwable $exception) {
                         $postOrder?->await($position);
 
@@ -67,22 +65,22 @@ final class ConcurrentFlatMapIterator implements ConcurrentIterator
 
                     $postOrder?->await($position);
 
-                    foreach ($iterable as $item) {
+                    foreach ($emission as $item) {
                         // Another concurrent coroutine already completed the queue
                         if ($queue->isComplete()) {
                             return;
                         }
 
-                        if ($item === $stop) {
-                            $queue->complete();
-
-                            $preOrder?->dispose();
-                            $postOrder?->dispose();
-
-                            return;
-                        }
-
                         $queue->push($item);
+                    }
+
+                    if ($emission->isFinal()) {
+                        $queue->complete();
+
+                        $preOrder?->dispose();
+                        $postOrder?->dispose();
+
+                        return;
                     }
 
                     $postOrder?->resume($position);

--- a/src/Internal/FlatMapOperation.php
+++ b/src/Internal/FlatMapOperation.php
@@ -3,6 +3,7 @@
 namespace Amp\Pipeline\Internal;
 
 use Amp\Pipeline\ConcurrentIterator;
+use Amp\Pipeline\Emission;
 
 /**
  * @template T
@@ -12,21 +13,14 @@ use Amp\Pipeline\ConcurrentIterator;
  */
 final class FlatMapOperation implements IntermediateOperation
 {
-    public static function getStopMarker(): object
-    {
-        static $marker;
-
-        return $marker ??= new \stdClass;
-    }
-
     /**
-     * @param \Closure(T, int):iterable<R> $flatMap
+     * @param \Closure(T, int):Emission<R> $flatMap
      */
     public function __construct(
         private readonly int $bufferSize,
         private readonly int $concurrency,
         private readonly bool $ordered,
-        private readonly \Closure $flatMap
+        private readonly \Closure $flatMap,
     ) {
     }
 
@@ -34,20 +28,7 @@ final class FlatMapOperation implements IntermediateOperation
     public function __invoke(ConcurrentIterator $source): ConcurrentIterator
     {
         if ($this->concurrency === 1) {
-            $stop = self::getStopMarker();
-
-            return new ConcurrentIterableIterator((function () use ($source, $stop): iterable {
-                foreach ($source as $position => $value) {
-                    $iterable = ($this->flatMap)($value, $position);
-                    foreach ($iterable as $item) {
-                        if ($item === $stop) {
-                            return;
-                        }
-
-                        yield $item;
-                    }
-                }
-            })(), $this->bufferSize);
+            return new ConcurrentIterableIterator($this->consume($source), $this->bufferSize);
         }
 
         return new ConcurrentFlatMapIterator(
@@ -57,5 +38,18 @@ final class FlatMapOperation implements IntermediateOperation
             $this->ordered,
             $this->flatMap,
         );
+    }
+
+    private function consume(ConcurrentIterator $source): \Generator
+    {
+        foreach ($source as $position => $value) {
+            $emission = ($this->flatMap)($value, $position);
+
+            yield from $emission;
+
+            if ($emission->isFinal()) {
+                return;
+            }
+        }
     }
 }

--- a/src/Pipeline.php
+++ b/src/Pipeline.php
@@ -37,7 +37,10 @@ final class Pipeline implements \IteratorAggregate
             $iterable = $iterable();
 
             if (!\is_iterable($iterable)) {
-                throw new \TypeError('Return value of argument #1 ($iterable) must be of type iterable, ' . \get_debug_type($iterable) . ' returned');
+                throw new \TypeError(\sprintf(
+                    'Return value of argument #1 ($iterable) must be of type iterable, %s returned',
+                    \get_debug_type($iterable),
+                ));
             }
         }
 
@@ -351,11 +354,11 @@ final class Pipeline implements \IteratorAggregate
      *
      * @template R
      *
-     * @param \Closure(T, int):iterable<R> $flatMap
+     * @param \Closure(T, int): Emission<R> $applicator
      *
      * @return self<R>
      */
-    public function flatMap(\Closure $flatMap): self
+    public function apply(\Closure $applicator): self
     {
         if ($this->used) {
             throw new \Error('Pipeline consumption has already been started');
@@ -365,11 +368,35 @@ final class Pipeline implements \IteratorAggregate
             $this->bufferSize,
             $this->concurrency,
             $this->ordered,
-            $flatMap,
+            $applicator,
         );
 
         /** @var self<R> */
         return $this;
+    }
+
+    /**
+     * Maps values, flattening one level.
+     *
+     * @template R
+     *
+     * @param \Closure(T, int):iterable<R> $flatMap
+     *
+     * @return self<R>
+     */
+    public function flatMap(\Closure $flatMap): self
+    {
+        return $this->apply(static function (mixed $value, int $position) use ($flatMap): Emission {
+            $iterable = $flatMap($value, $position);
+
+            if (!\is_iterable($iterable)) {
+                throw new \TypeError(
+                    \sprintf('flatMap callback must return an iterable, %s returned', \get_debug_type($iterable)),
+                );
+            }
+
+            return Emission::of($iterable);
+        });
     }
 
     /**
@@ -383,7 +410,7 @@ final class Pipeline implements \IteratorAggregate
      */
     public function map(\Closure $map): self
     {
-        return $this->flatMap(static fn (mixed $value) => [$map($value)]);
+        return $this->apply(static fn (mixed $value) => Emission::of([$map($value)]));
     }
 
     /**
@@ -393,7 +420,7 @@ final class Pipeline implements \IteratorAggregate
      */
     public function filter(\Closure $filter): static
     {
-        return $this->flatMap(static fn (mixed $value) => $filter($value) ? [$value] : []);
+        return $this->apply(static fn (mixed $value) => Emission::of($filter($value) ? [$value] : []));
     }
 
     /**
@@ -403,10 +430,10 @@ final class Pipeline implements \IteratorAggregate
      */
     public function tap(\Closure $tap): static
     {
-        return $this->flatMap(static function (mixed $value) use ($tap): array {
+        return $this->apply(static function (mixed $value) use ($tap): Emission {
             $tap($value);
 
-            return [$value];
+            return Emission::of([$value]);
         });
     }
 
@@ -442,14 +469,14 @@ final class Pipeline implements \IteratorAggregate
      */
     public function skip(int $count): static
     {
-        return $this->flatMap(static function (mixed $value) use ($count): array {
+        return $this->apply(static function (mixed $value) use ($count): Emission {
             static $i = 0;
 
             if ($i++ < $count) {
-                return [];
+                return Emission::of([]);
             }
 
-            return [$value];
+            return Emission::of([$value]);
         });
     }
 
@@ -462,13 +489,13 @@ final class Pipeline implements \IteratorAggregate
      */
     public function skipWhile(\Closure $predicate): static
     {
-        return $this->flatMap(
-            static function (mixed $value, int $position) use ($predicate): array {
+        return $this->apply(
+            static function (mixed $value, int $position) use ($predicate): Emission {
                 static $sequence = new Sequence();
                 static $skipping = true;
 
                 if (!$skipping) {
-                    return [$value];
+                    return Emission::of([$value]);
                 }
 
                 $predicateResult = $predicate($value);
@@ -477,12 +504,12 @@ final class Pipeline implements \IteratorAggregate
 
                 /** @psalm-suppress RedundantCondition $skipping may be modified by a concurrent call */
                 if ($skipping && $predicateResult) {
-                    return [];
+                    return Emission::of([]);
                 }
 
                 $skipping = false;
 
-                return [$value];
+                return Emission::of([$value]);
             }
         );
     }
@@ -492,21 +519,18 @@ final class Pipeline implements \IteratorAggregate
      */
     public function take(int $count): static
     {
-        return $this->flatMap(static function (mixed $value) use ($count): array {
+        return $this->apply(static function (mixed $value) use ($count): Emission {
             static $i = 0;
 
             if (++$i < $count) {
-                return [$value];
+                return Emission::of([$value]);
             }
-
-            /** @var T $stopMarker Fake stop marker as type T. */
-            $stopMarker = FlatMapOperation::getStopMarker();
 
             if ($i === $count) {
-                return [$value, $stopMarker];
+                return Emission::end([$value]);
             }
 
-            return [$stopMarker];
+            return Emission::end();
         });
     }
 
@@ -517,13 +541,13 @@ final class Pipeline implements \IteratorAggregate
      */
     public function takeWhile(\Closure $predicate): static
     {
-        return $this->flatMap(
-            static function (mixed $value, int $position) use ($predicate): array {
+        return $this->apply(
+            static function (mixed $value, int $position) use ($predicate): Emission {
                 static $sequence = new Sequence();
                 static $taking = true;
 
                 if (!$taking) {
-                    return [FlatMapOperation::getStopMarker()];
+                    return Emission::end();
                 }
 
                 $predicateResult = $predicate($value);
@@ -532,13 +556,12 @@ final class Pipeline implements \IteratorAggregate
 
                 /** @psalm-suppress RedundantCondition $taking may be modified by a concurrent call */
                 if ($taking && $predicateResult) {
-                    return [$value];
+                    return Emission::of([$value]);
                 }
 
                 $taking = false;
 
-                /** @var T[] */
-                return [FlatMapOperation::getStopMarker()];
+                return Emission::end();
             }
         );
     }

--- a/test/ApplyTest.php
+++ b/test/ApplyTest.php
@@ -1,0 +1,210 @@
+<?php declare(strict_types=1);
+
+namespace Amp\Pipeline;
+
+use Amp\PHPUnit\AsyncTestCase;
+use Amp\PHPUnit\TestException;
+use function Amp\delay;
+
+class ApplyTest extends AsyncTestCase
+{
+    public function provideEmissionScenarios(): \Generator
+    {
+        yield 'expand-each-value-into-multiple' => [
+            [1, 2, 3],
+            static fn (int $value) => Emission::of([$value, $value * 10]),
+            [1, 10, 2, 20, 3, 30],
+        ];
+
+        yield 'filter-via-empty-emission' => [
+            [1, 2, 3, 4, 5],
+            static fn (int $value) => Emission::of($value % 2 ? [$value] : []),
+            [1, 3, 5],
+        ];
+
+        yield 'one-to-one-mapping' => [
+            [1, 2, 3],
+            static fn (int $value) => Emission::of([$value + 1]),
+            [2, 3, 4],
+        ];
+
+        yield 'end-emits-remaining-then-stops' => [
+            [1, 2, 3, 4, 5],
+            static fn (int $value) => $value === 3 ? Emission::end([$value]) : Emission::of([$value]),
+            [1, 2, 3],
+        ];
+
+        yield 'end-with-empty-stops-immediately' => [
+            [1, 2, 3, 4, 5],
+            static fn (int $value) => $value === 3 ? Emission::end() : Emission::of([$value]),
+            [1, 2],
+        ];
+
+        yield 'final-emission-on-first-value' => [
+            [1, 2, 3],
+            static fn (int $value) => Emission::end([$value]),
+            [1],
+        ];
+
+        yield 'generator-emission' => [
+            [1, 2],
+            static function (int $value): Emission {
+                return Emission::of((static function () use ($value): \Generator {
+                    yield $value;
+                    yield $value + 100;
+                })());
+            },
+            [1, 101, 2, 102],
+        ];
+    }
+
+    /**
+     * @dataProvider provideEmissionScenarios
+     *
+     * @param list<int> $values
+     * @param \Closure(int, int):Emission $applicator
+     * @param list<int> $expected
+     */
+    public function testApply(array $values, \Closure $applicator, array $expected): void
+    {
+        $result = Pipeline::fromIterable($values)
+            ->apply($applicator)
+            ->toArray();
+
+        self::assertSame($expected, $result);
+    }
+
+    /**
+     * @dataProvider provideEmissionScenarios
+     *
+     * @param list<int> $values
+     * @param \Closure(int, int):Emission $applicator
+     * @param list<int> $expected
+     */
+    public function testConcurrent(array $values, \Closure $applicator, array $expected): void
+    {
+        $result = Pipeline::fromIterable($values)
+            ->concurrent(3)
+            ->apply($applicator)
+            ->toArray();
+
+        self::assertSame($expected, $result);
+    }
+
+    public function testPositionPassedToApplicator(): void
+    {
+        $positions = [];
+
+        Pipeline::fromIterable(['a', 'b', 'c'])
+            ->apply(static function (string $value, int $position) use (&$positions): Emission {
+                $positions[] = $position;
+
+                return Emission::of([$value]);
+            })
+            ->toArray();
+
+        self::assertSame([0, 1, 2], $positions);
+    }
+
+    public function testEndStopsConsumingSource(): void
+    {
+        $invocationCount = 0;
+
+        $source = Pipeline::fromIterable(function () use (&$invocationCount): \Generator {
+            foreach (\range(1, 5) as $value) {
+                ++$invocationCount;
+                yield $value;
+            }
+        });
+
+        $result = $source
+            ->apply(static fn (int $value) => $value === 2 ? Emission::end([$value]) : Emission::of([$value]))
+            ->toArray();
+
+        self::assertSame([1, 2], $result);
+
+        // Eager consumption pulls in next value.
+        self::assertSame(\count($result) + 1, $invocationCount);
+    }
+
+    public function testConcurrentOrdered(): void
+    {
+        $values = Pipeline::fromIterable(\range(1, 9))
+            ->concurrent(4)
+            ->apply(static function (int $value): Emission {
+                delay(0.01);
+
+                return Emission::of([$value + 1]);
+            })
+            ->toArray();
+
+        self::assertSame([2, 3, 4, 5, 6, 7, 8, 9, 10], $values);
+    }
+
+    public function testUnorderedConcurrentEnd(): void
+    {
+        $size = 50;
+        $concurrency = 4;
+
+        // The final emission completes the underlying queue; with multiple unordered
+        // coroutines this must not complete the queue more than once.
+        $values = Pipeline::fromIterable(\range(1, 100))
+            ->concurrent($concurrency)
+            ->unordered()
+            ->apply(static function (int $value) use ($size): Emission {
+                static $i = 0;
+
+                if (++$i < $size) {
+                    return Emission::of([$value]);
+                }
+
+                return Emission::end([$value]);
+            })
+            ->toArray();
+
+        // Consumption stops early once the final emission is reached. Concurrent coroutines may
+        // emit a few values past the threshold before the queue completes, but never all 100.
+        self::assertGreaterThanOrEqual($size, \count($values));
+        self::assertLessThan($size + $concurrency, \count($values));
+    }
+
+    public function testApplicatorThrows(): void
+    {
+        $exception = new TestException();
+
+        $iterator = Pipeline::fromIterable([1, 2, 3])
+            ->apply(fn () => throw $exception)
+            ->getIterator();
+
+        $this->expectExceptionObject($exception);
+
+        $iterator->continue();
+    }
+
+    public function testPipelineFails(): void
+    {
+        $exception = new TestException();
+        $source = new Queue;
+
+        $iterator = $source->pipe()
+            ->apply(static fn (mixed $value) => Emission::of([$value]))
+            ->getIterator();
+
+        $source->error($exception);
+
+        $this->expectExceptionObject($exception);
+
+        $iterator->continue();
+    }
+
+    public function testConsumptionAlreadyStarted(): void
+    {
+        $pipeline = Pipeline::fromIterable([1, 2, 3]);
+        $pipeline->getIterator();
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Pipeline consumption has already been started');
+
+        $pipeline->apply(static fn (int $value) => Emission::of([$value]));
+    }
+}


### PR DESCRIPTION
I had the idea to expose a way for a mapper function to stop pipeline consumption early, like we do internally with `take()` and `takeWhile()`. This new `apply()` function plus `Emission` class was the result. It is then used to implement other methods such as `take()`, etc.

I'm not certain this is necessary. `takeWhile()` can fill this use-case, but that path does require defining the mapping and stop logic in separate functions.